### PR TITLE
Use class toggle grammar

### DIFF
--- a/src/Todo.svelte
+++ b/src/Todo.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <style>
-  .done-true {
+  .done {
     color: gray;
     text-decoration: line-through;
   }
@@ -21,6 +21,6 @@
     type="checkbox"
     checked={todo.done}
     on:change={() => dispatch('toggleDone')} />
-  <span class={'done-' + todo.done}>{todo.text}</span>
+  <span class:done={todo.done}>{todo.text}</span>
   <button on:click={() => dispatch('delete')}>Delete</button>
 </li>


### PR DESCRIPTION
In order to conditionally add a class to an element
	<span class="only-sometimes">

Svelte offers a great solution
	<span class:only-sometimes={your_condition_here}>

In this way there is no need for funny class names or use of class names
that are defined nowhere.